### PR TITLE
Change a call of pkcs11h_mem_free to _pkcs11h_mem_free

### DIFF
--- a/lib/pkcs11h-openssl.c
+++ b/lib/pkcs11h-openssl.c
@@ -893,7 +893,7 @@ pkcs11h_openssl_getX509 (
 cleanup:
 
 	if (certificate_blob != NULL) {
-		pkcs11h_mem_free((void *)&certificate_blob);
+		_pkcs11h_mem_free((void *)&certificate_blob);
 	}
 
 	if (rv != CKR_OK) {


### PR DESCRIPTION
This was necessary to build the latest version of the code on OS X 10.10.
